### PR TITLE
Skip raising error when connection to the database is not established

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    database_validations (0.3.1)
+    database_validations (0.3.2)
       activerecord (>= 3.2, < 6)
 
 GEM

--- a/lib/database_validations/helpers.rb
+++ b/lib/database_validations/helpers.rb
@@ -3,8 +3,8 @@ module DatabaseValidations
     module_function
 
     def raise_if_index_missed!(model, columns)
-      index = model.connection
-                .indexes(model.table_name)
+      connection = model.connection rescue return
+      index = connection.indexes(model.table_name)
                 .select(&:unique)
                 .find { |index| index.columns.map(&:to_s).sort == columns }
 

--- a/lib/database_validations/version.rb
+++ b/lib/database_validations/version.rb
@@ -1,3 +1,3 @@
 module DatabaseValidations
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
For example, the fix prevents us from getting errors when you create the database (i.e. via `rake db:create`) when your model is already loaded.