### PR TITLE
Add table name to missing index warning message

### DIFF
--- a/lib/database_validations/validations/adapters/base_adapter.rb
+++ b/lib/database_validations/validations/adapters/base_adapter.rb
@@ -47,6 +47,11 @@ module DatabaseValidations
         self.class::SUPPORTED_OPTIONS
       end
 
+      # @return [String]
+      def table_name
+        model.table_name
+      end
+
       private
 
       attr_reader :model

--- a/lib/database_validations/validations/errors.rb
+++ b/lib/database_validations/validations/errors.rb
@@ -7,19 +7,19 @@ module DatabaseValidations
     end
 
     class IndexNotFound < Base
-      attr_reader :columns, :where_clause, :index_name, :available_indexes
+      attr_reader :columns, :where_clause, :index_name, :available_indexes, :table_name
 
-      def initialize(columns, where_clause, index_name, available_indexes)
+      def initialize(columns, where_clause, index_name, available_indexes, table_name)
         @columns = columns
         @where_clause = where_clause
         @available_indexes = available_indexes
         @index_name = index_name
 
         text = if index_name
-                 "No unique index found with name: \"#{index_name}\". "\
+                 "No unique index found with name: \"#{index_name}\" in table \"#{table_name}\". "\
                  "Available indexes are: #{self.available_indexes.map(&:name)}. "
                else
-                 "No unique index found with #{columns_and_where_text(columns, where_clause)}. "\
+                 "No unique index found with #{columns_and_where_text(columns, where_clause)} in table \"#{table_name}\". "\
                  "Available indexes are: [#{self.available_indexes.map { |ind| columns_and_where_text(ind.columns, ind.where) }.join(', ')}]. "
                end
 

--- a/lib/database_validations/validations/uniqueness_options.rb
+++ b/lib/database_validations/validations/uniqueness_options.rb
@@ -97,7 +97,7 @@ module DatabaseValidations
     def raise_if_index_missed!
       unless (index_name && adapter.find_index_by_name(index_name.to_s)) ||
         (!index_name && adapter.find_index(columns, where_clause))
-        raise Errors::IndexNotFound.new(columns, where_clause, index_name, adapter.indexes)
+        raise Errors::IndexNotFound.new(columns, where_clause, index_name, adapter.indexes, adapter.table_name)
       end
     end
   end

--- a/spec/validations/uniqueness_handlers_spec.rb
+++ b/spec/validations/uniqueness_handlers_spec.rb
@@ -451,7 +451,7 @@ RSpec.describe 'validates_db_uniqueness_of' do
           expect do
             define_class { |klass| klass.validates_db_uniqueness_of :field }
           end.to raise_error DatabaseValidations::Errors::IndexNotFound,
-                             'No unique index found with columns: ["field"]. '\
+                             'No unique index found with columns: ["field"] in table "entities". '\
                              'Available indexes are: []. '\
                              'Use ENV[\'SKIP_DB_UNIQUENESS_VALIDATOR_INDEX_CHECK\']=true in case you want to skip the check. '\
                              'For example, when you run migrations.'
@@ -490,7 +490,7 @@ RSpec.describe 'validates_db_uniqueness_of' do
               klass.validates_db_uniqueness_of :field_1, scope: :field_2
             end
           end.to raise_error DatabaseValidations::Errors::IndexNotFound,
-                             'No unique index found with columns: ["field_1", "field_2"]. '\
+                             'No unique index found with columns: ["field_1", "field_2"] in table "entities". '\
                              'Available indexes are: []. '\
                              'Use ENV[\'SKIP_DB_UNIQUENESS_VALIDATOR_INDEX_CHECK\']=true in case you want to skip the check. '\
                              'For example, when you run migrations.'
@@ -532,7 +532,7 @@ RSpec.describe 'validates_db_uniqueness_of' do
               klass.validates_db_uniqueness_of :field_2
             end
           end.to raise_error DatabaseValidations::Errors::IndexNotFound,
-                             'No unique index found with columns: ["field_2"]. '\
+                             'No unique index found with columns: ["field_2"] in table "entities". '\
                              'Available indexes are: [columns: ["field_1"]]. '\
                              'Use ENV[\'SKIP_DB_UNIQUENESS_VALIDATOR_INDEX_CHECK\']=true in case you want to skip the check. '\
                              'For example, when you run migrations.'
@@ -584,7 +584,7 @@ RSpec.describe 'validates_db_uniqueness_of' do
           expect do
             define_class { |klass| klass.validates_db_uniqueness_of :field, where: '(field < 1)' }
           end.to raise_error DatabaseValidations::Errors::IndexNotFound,
-                             'No unique index found with columns: ["field"] and where: (field < 1). '\
+                             'No unique index found with columns: ["field"] and where: (field < 1) in table "entities". '\
                              'Available indexes are: [columns: ["field"] and where: (field > 1)]. '\
                              'Use ENV[\'SKIP_DB_UNIQUENESS_VALIDATOR_INDEX_CHECK\']=true in case you want to skip the check. '\
                              'For example, when you run migrations.'
@@ -624,7 +624,7 @@ RSpec.describe 'validates_db_uniqueness_of' do
           expect do
             define_class { |klass| klass.validates_db_uniqueness_of :field, index_name: :missing_index }
           end.to raise_error DatabaseValidations::Errors::IndexNotFound,
-                             'No unique index found with name: "missing_index". '\
+                             'No unique index found with name: "missing_index" in table "entities". '\
                              'Available indexes are: ["unique_index"]. '\
                              'Use ENV[\'SKIP_DB_UNIQUENESS_VALIDATOR_INDEX_CHECK\']=true in case you want to skip the check. '\
                              'For example, when you run migrations.'


### PR DESCRIPTION
Clarify the warning message by adding a table name to it.

Before:
```
No unique index found with columns: ["color"]. Available indexes are: [].
```

After:
```
No unique index found with columns: ["color"] in table "fruits". Available indexes are: [].
```