### PR TITLE
Use local MySQL user

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ end
 ## Development
 
 You need to have installed and running `postgresql` and `mysql`. 
-And for each adapter manually create a database called `database_validations_test`. 
+And for each adapter manually create a database called `database_validations_test` accessible to your local user. 
 
 Then, run `rake spec` to run the tests.
 

--- a/benchmarks/composed_benchmarks.rb
+++ b/benchmarks/composed_benchmarks.rb
@@ -9,8 +9,7 @@ require_relative 'gc_suite'
   },
   {
     adapter: 'mysql2',
-    database: 'database_validations_test',
-    username: 'root'
+    database: 'database_validations_test'
   }
 ].each do |database_configuration|
   ActiveRecord::Base.establish_connection(database_configuration)

--- a/benchmarks/db_belongs_to_benchmark.rb
+++ b/benchmarks/db_belongs_to_benchmark.rb
@@ -9,8 +9,7 @@ require_relative 'gc_suite'
   },
   {
     adapter: 'mysql2',
-    database: 'database_validations_test',
-    username: 'root'
+    database: 'database_validations_test'
   }
 ].each do |database_configuration|
   ActiveRecord::Base.establish_connection(database_configuration)

--- a/benchmarks/uniqueness_validator_benchmark.rb
+++ b/benchmarks/uniqueness_validator_benchmark.rb
@@ -13,8 +13,7 @@ require_relative 'gc_suite'
   },
   {
     adapter: 'mysql2',
-    database: 'database_validations_test',
-    username: 'root'
+    database: 'database_validations_test'
   }
 ].each do |database_configuration|
   ActiveRecord::Base.establish_connection(database_configuration)

--- a/spec/validations/belongs_to_handlers_spec.rb
+++ b/spec/validations/belongs_to_handlers_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'db_belongs_to' do
   end
 
   describe 'mysql' do
-    before(:all) { define_db.call(adapter: 'mysql2', database: 'database_validations_test', username: 'root') }
+    before(:all) { define_db.call(adapter: 'mysql2', database: 'database_validations_test') }
     include_examples 'works as belongs_to'
   end
 end

--- a/spec/validations/uniqueness_handlers_spec.rb
+++ b/spec/validations/uniqueness_handlers_spec.rb
@@ -688,7 +688,7 @@ RSpec.describe 'validates_db_uniqueness_of' do
   end
 
   describe 'mysql' do
-    before { define_db.call(adapter: 'mysql2', database: 'database_validations_test', username: 'root') }
+    before { define_db.call(adapter: 'mysql2', database: 'database_validations_test') }
 
     include_examples 'works as expected'
     include_examples 'supports index_name option'


### PR DESCRIPTION
Running MySQL specs with a non-empty password for the root user was a pain.
After this change, the specs/benchmarks are using the default local (e.g. `whoami`) user for MySQL just like they do for Postgres.

Example MySQL setup for `database_validations`:
```
$ mysql -uroot --password
mysql> CREATE DATABASE database_validations_test;
mysql> CREATE USER pirj@localhost IDENTIFIED BY '';
mysql> GRANT ALL PRIVILEGES ON database_validations_test.* TO pirj@localhost;
```