### PR TITLE
Improve benchmarks code

### DIFF
--- a/benchmarks/composed_benchmarks.rb
+++ b/benchmarks/composed_benchmarks.rb
@@ -78,22 +78,15 @@ require_relative 'gc_suite'
   # ===Save only valid===
   Benchmark.ips do |x|
     x.config(suite: suite)
-    x.report('old way') { field += 1; Users1.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
-    x.report('new way') { field += 1; Users2.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
-  end
 
-  # ===Each hundredth is invalid===
-  Benchmark.ips do |x|
-    x.config(suite: suite)
-    x.report('old way') { field += 1; field % 100 == 0 ? Users1.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') : Users1.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
-    x.report('new way') { field += 1; field % 100 == 0 ? Users2.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') : Users2.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
-  end
+    x.report("#{database_configuration[:adapter]} optimistic: without gem") { field += 1; Users1.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
+    x.report("#{database_configuration[:adapter]} optimistic: with gem") { field += 1; Users2.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
 
-  # ===Save only invalid===
-  Benchmark.ips do |x|
-    x.config(suite: suite)
-    x.report('old way') { Users1.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') }
-    x.report('new way') { Users2.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') }
+    x.report("#{database_configuration[:adapter]} realistic: without gem") { field += 1; field % 100 == 0 ? Users1.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') : Users1.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
+    x.report("#{database_configuration[:adapter]} realistic: with gem") { field += 1; field % 100 == 0 ? Users2.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') : Users2.create(company_id: company.id, country_id: country.id, full_name: field.to_s, email: field.to_s) }
+
+    x.report("#{database_configuration[:adapter]} pessimistic: without gem") { Users1.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') }
+    x.report("#{database_configuration[:adapter]} pessimistic: with gem") { Users2.create(company_id: -1, country_id: -1, full_name: 'invalid', email: 'invalid') }
   end
 
   # Clear the DB

--- a/benchmarks/db_belongs_to_benchmark.rb
+++ b/benchmarks/db_belongs_to_benchmark.rb
@@ -47,27 +47,19 @@ require_relative 'gc_suite'
   # ===Benchmarks===
   suite = GCSuite.new
   company = Company.create!
-
-  # ===Save using ID===
-  Benchmark.ips do |x|
-    x.config(suite: suite)
-    x.report('belongs_to') { Users1.create(company_id: company.id) }
-    x.report('db_belongs_to') { Users2.create(company_id: company.id) }
-  end
-
-  # ===Each hundredth is not found===
   field = 0
-  Benchmark.ips do |x|
-    x.config(suite: suite)
-    x.report('belongs_to') { field += 1; field % 100 == 0 ? Users1.create(company_id: -1) : Users1.create(company_id: company.id) }
-    x.report('db_belongs_to') { field += 1; field % 100 == 0 ? Users2.create(company_id: -1) : Users2.create(company_id: company.id) }
-  end
 
-  # ===Not found===
   Benchmark.ips do |x|
     x.config(suite: suite)
-    x.report('belongs_to') { Users1.create(company_id: -1) }
-    x.report('db_belongs_to') { Users2.create(company_id: -1) }
+
+    x.report("#{database_configuration[:adapter]} only existing: belongs_to") { Users1.create(company_id: company.id) }
+    x.report("#{database_configuration[:adapter]} only existing: db_belongs_to") { Users2.create(company_id: company.id) }
+
+    x.report("#{database_configuration[:adapter]} each hundredth does not exist: belongs_to") { field += 1; field % 100 == 0 ? Users1.create(company_id: -1) : Users1.create(company_id: company.id) }
+    x.report("#{database_configuration[:adapter]} each hundredth does not exist: db_belongs_to") { field += 1; field % 100 == 0 ? Users2.create(company_id: -1) : Users2.create(company_id: company.id) }
+
+    x.report("#{database_configuration[:adapter]} only missing: belongs_to") { Users1.create(company_id: -1) }
+    x.report("#{database_configuration[:adapter]} only missing: db_belongs_to") { Users2.create(company_id: -1) }
   end
 
   # Clear the DB


### PR DESCRIPTION
The benchmarks were not properly normalized, and for some reason 'each
hundredth' was significantly faster than 'only existing' for
`*belongs_to`.

The order of 'with gem'/'without gem' was not consistent across
benchmarks.

The order optimistic-realistic-pessimistic was not consistent across
benchmarks.