### PR TITLE
Add cops for RuboCop

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,16 @@ describe 'validations' do
 end
 ```
 
+## Using with RuboCop
+
+DatabaseValidations provides custom cops for RuboCop to help you consistently apply the improvements. To use them, use
+`rubocop --require database_validations/rubocop/cops` or add to your `.rubocop.yml` file:
+
+```
+require:
+  - database_validations/rubocop/cops
+```
+
 ## Development
 
 You need to have installed and running `postgresql` and `mysql`. 

--- a/lib/database_validations/rubocop/cop/belongs_to.rb
+++ b/lib/database_validations/rubocop/cop/belongs_to.rb
@@ -1,0 +1,46 @@
+module RuboCop
+  module Cop
+    module DatabaseValidations
+      # Use `db_belongs`_to instead of `belongs_to`.
+      #
+      # @example
+      #   # bad
+      #   belongs_to :company
+      #
+      #   # good
+      #   db_belongs_to :company
+      #
+      class BelongsTo < Cop
+        MSG = 'Use `db_belongs_to`.'.freeze
+
+        NON_SUPPORTED_OPTIONS = %i[
+          optional
+          required
+          polymorphic
+          foreign_type
+        ].freeze
+
+        def_node_matcher :belongs_to?, '(send nil? :belongs_to ...)'
+        def_node_matcher :option_name, '(pair (sym $_) ...)'
+
+        def on_send(node)
+          return unless belongs_to?(node)
+          return unless supported?(node)
+
+          add_offense(node, location: :selector)
+        end
+
+        private
+
+        def supported?(node)
+          options = node.arguments.last
+          return true unless options.hash_type?
+
+          options.each_child_node.none? do |option|
+            NON_SUPPORTED_OPTIONS.include? option_name(option)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/database_validations/rubocop/cop/uniqueness_of.rb
+++ b/lib/database_validations/rubocop/cop/uniqueness_of.rb
@@ -1,0 +1,41 @@
+module RuboCop
+  module Cop
+    module DatabaseValidations
+      # Use `validates_db_uniqueness_of` for uniqueness validation.
+      #
+      # @example
+      #   # bad
+      #   validates :slug, uniqueness: true
+      #   validates :address, uniqueness: { scope: :user_id }
+      #
+      #   # good
+      #   validates_db_uniqueness_of :slug
+      #   validates_db_uniqueness_of :address, scope: :user_id
+      #
+      class UniquenessOf < Cop
+        MSG = 'Use `validates_db_uniqueness_of`.'.freeze
+
+        def_node_matcher :uniquness_validation?, '(pair (sym :uniqueness) $_)'
+
+        def on_send(node)
+          return unless node.method_name == :validates
+
+          uniqueness(node) do |option|
+            add_offense(option)
+          end
+        end
+
+        private
+
+        def uniqueness(node)
+          options = node.arguments.last
+          return unless options.hash_type?
+
+          options.each_child_node do |child|
+            yield child if uniquness_validation?(child)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/database_validations/rubocop/cops.rb
+++ b/lib/database_validations/rubocop/cops.rb
@@ -1,0 +1,2 @@
+require 'database_validations/rubocop/cop/belongs_to'
+require 'database_validations/rubocop/cop/uniqueness_of'

--- a/spec/rubocop/cop/belongs_to_spec.rb
+++ b/spec/rubocop/cop/belongs_to_spec.rb
@@ -1,0 +1,43 @@
+require 'rubocop/spec_helper'
+
+RSpec.describe RuboCop::Cop::DatabaseValidations::BelongsTo do # rubocop:disable RSpec/FilePath
+  subject(:cop) { described_class.new }
+
+  it 'detects `belongs_to`: true``' do
+    expect_offense(<<-RUBY)
+      belongs_to :company
+      ^^^^^^^^^^ Use `db_belongs_to`.
+    RUBY
+  end
+
+  it 'detects `belongs_to` with an option' do
+    expect_offense(<<-RUBY)
+      belongs_to :company, touch: true
+      ^^^^^^^^^^ Use `db_belongs_to`.
+    RUBY
+  end
+
+  it 'ignores `belongs_to` with optional' do
+    expect_no_offenses(<<-RUBY)
+      belongs_to :company, optional: true
+    RUBY
+  end
+
+  it 'ignores `belongs_to` with required' do
+    expect_no_offenses(<<-RUBY)
+      belongs_to :company, required: true
+    RUBY
+  end
+
+  it 'ignores `belongs_to` with polymorphic' do
+    expect_no_offenses(<<-RUBY)
+      belongs_to :company, polymorphic: true
+    RUBY
+  end
+
+  it 'ignores `belongs_to` with foreign_type' do
+    expect_no_offenses(<<-RUBY)
+      belongs_to :role, foreign_type: User
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/uniqeness_of_spec.rb
+++ b/spec/rubocop/cop/uniqeness_of_spec.rb
@@ -1,0 +1,26 @@
+require 'rubocop/spec_helper'
+
+RSpec.describe RuboCop::Cop::DatabaseValidations::UniquenessOf do # rubocop:disable RSpec/FilePath
+  subject(:cop) { described_class.new }
+
+  it 'detects `uniqueness: true`' do
+    expect_offense(<<-RUBY)
+      validates :slug, uniqueness: true
+                       ^^^^^^^^^^^^^^^^ Use `validates_db_uniqueness_of`.
+    RUBY
+  end
+
+  it 'detects `uniqueness` on multiple fields' do
+    expect_offense(<<-RUBY)
+      validates :code, :name, uniqueness: true
+                              ^^^^^^^^^^^^^^^^ Use `validates_db_uniqueness_of`.
+    RUBY
+  end
+
+  it 'detects conditional uniqeuness valudation' do
+    expect_offense(<<-RUBY)
+      validates :main, uniqueness: {scope: :client_id}, if: -> { main? && main_changed? }
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `validates_db_uniqueness_of`.
+    RUBY
+  end
+end

--- a/spec/rubocop/spec_helper.rb
+++ b/spec/rubocop/spec_helper.rb
@@ -1,0 +1,11 @@
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'database_validations/rubocop/cops'
+
+RSpec.shared_context 'rubocop config', :rubocop_config do
+  let(:config) { RuboCop::Config.new(described_class.cop_name => cop_config) }
+end
+
+RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+end


### PR DESCRIPTION
Added cops for both `db_uniquness_of` and `db_belong_to`. 

They don't autocorrect (yet). Autocorrection for `db_belongs_to` seems trivial, while `db_uniquness_of` have some more complicated usages. In any case, auto-corrections will be added in further, separate PRs