### PR TITLE
Implement fallback to query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ example/db/*.sqlite3
 example/tmp
 example/log
 example/Gemfile.lock
+
+.ruby-version
+.ruby-gemset

--- a/lib/database_validations/lib/rescuer.rb
+++ b/lib/database_validations/lib/rescuer.rb
@@ -24,13 +24,19 @@ module DatabaseValidations
       keys.each do |key|
         attribute_validator = instance._db_validators[key]
 
-        if attribute_validator
-          attribute_validator.validator.apply_error(instance, attribute_validator.attribute)
-          return true
-        end
+        next unless attribute_validator
+
+        return process_validator(instance, attribute_validator)
       end
 
       false
+    end
+
+    def process_validator(instance, attribute_validator)
+      return false unless attribute_validator.validator.perform_db_validation?
+
+      attribute_validator.validator.apply_error(instance, attribute_validator.attribute)
+      true
     end
   end
 end

--- a/lib/database_validations/lib/validators/db_presence_validator.rb
+++ b/lib/database_validations/lib/validators/db_presence_validator.rb
@@ -21,6 +21,10 @@ module DatabaseValidations
       Checkers::DbPresenceValidator.validate!(self)
     end
 
+    def perform_db_validation?
+      true
+    end
+
     # TODO: add support of optional db_belongs_to
     def validate(record)
       if record._database_validations_fallback


### PR DESCRIPTION
Sometimes we don't want to sacrifice UX but usage of both (DB and non-DB) uniqueness validators produces 2 DB queries on validation instead of one.
This new `fallback_to_query` option makes DB uniqueness validation to act exactly as the Rails one but with an additional data consistency check layer in case of race conditions.