### PR TITLE
Remove deprecation warning connection_config for rails 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,41 @@
 version: 2.1
+
+ruby-env: &ruby-env
+  BUNDLE_JOBS: 3
+  BUNDLE_RETRY: 3
+  BUNDLE_PATH: vendor/bundle
+  DB_HOST: 127.0.0.1
+  DB_USER: root
+  DB_PASSWORD: test
+
+postgres-env: &postgres-env
+  POSTGRES_USER: root
+  POSTGRES_DB: database_validations_test
+  POSTGRES_PASSWORD: test
+
+mysql-env: &mysql-env
+  MYSQL_ROOT_HOST: '%'
+  MYSQL_ALLOW_EMPTY_PASSWORD: yes
+  MYSQL_ROOT_PASSWORD: test
+  MYSQL_DATABASE: database_validations_test
+  MYSQL_USER: root
+
 jobs:
   rails42:
     parallelism: 3
     docker:
       - image: circleci/ruby:2.4
         environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          BUNDLE_PATH: vendor/bundle
+          <<: *ruby-env
           GEMFILE_PATH: gemfiles/rails42.gemfile
-          DB_HOST: 127.0.0.1
-          DB_USER: root
-          DB_PASSWORD: test
 
       - image: circleci/postgres:9.6
         environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: database_validations_test
-          POSTGRES_PASSWORD: test
+          <<: *postgres-env
 
       - image: circleci/mysql:5.6
         environment:
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: test
-          MYSQL_DATABASE: database_validations_test
-          MYSQL_USER: root
+          <<: *mysql-env
 
     steps: &steps
       - checkout
@@ -67,56 +77,34 @@ jobs:
     docker:
       - image: circleci/ruby:2.5
         environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          BUNDLE_PATH: vendor/bundle
+          <<: *ruby-env
           GEMFILE_PATH: gemfiles/rails52.gemfile
-          DB_HOST: 127.0.0.1
-          DB_USER: root
-          DB_PASSWORD: test
 
       - image: circleci/postgres:9.6
         environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: database_validations_test
-          POSTGRES_PASSWORD: test
+          <<: *postgres-env
 
       - image: circleci/mysql:5.6
         environment:
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: test
-          MYSQL_DATABASE: database_validations_test
-          MYSQL_USER: root
+          <<: *mysql-env
 
     steps: *steps
 
-  rails60:
+  rails61:
     parallelism: 3
     docker:
-      - image: circleci/ruby:2.6
+      - image: circleci/ruby:2.7
         environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          BUNDLE_PATH: vendor/bundle
-          GEMFILE_PATH: gemfiles/rails60.gemfile
-          DB_HOST: 127.0.0.1
-          DB_USER: root
-          DB_PASSWORD: test
+          <<: *ruby-env
+          GEMFILE_PATH: gemfiles/rails61.gemfile
 
       - image: circleci/postgres:9.6
         environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: database_validations_test
-          POSTGRES_PASSWORD: test
+          <<: *postgres-env
 
       - image: circleci/mysql:5.6
         environment:
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: test
-          MYSQL_DATABASE: database_validations_test
-          MYSQL_USER: root
+          <<: *mysql-env
 
     steps: *steps
 
@@ -125,27 +113,16 @@ jobs:
     docker:
       - image: circleci/ruby:latest
         environment:
-          BUNDLE_JOBS: 3
-          BUNDLE_RETRY: 3
-          BUNDLE_PATH: vendor/bundle
+          <<: *ruby-env
           GEMFILE_PATH: gemfiles/railsmaster.gemfile
-          DB_HOST: 127.0.0.1
-          DB_USER: root
-          DB_PASSWORD: test
 
       - image: circleci/postgres:9.6
         environment:
-          POSTGRES_USER: root
-          POSTGRES_DB: database_validations_test
-          POSTGRES_PASSWORD: test
+          <<: *postgres-env
 
       - image: circleci/mysql:5.6
         environment:
-          MYSQL_ROOT_HOST: '%'
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: test
-          MYSQL_DATABASE: database_validations_test
-          MYSQL_USER: root
+          <<: *mysql-env
 
     steps: *steps
 
@@ -155,4 +132,4 @@ workflows:
     jobs:
       - rails42
       - rails52
-      - rails60
+      - rails61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.5] - Not released yet
+### Fixes
+
+- Remove deprecation warning when `connection_config` is used in Rails 6.1 (Use connection_db_config instead). Thanks [Alfonso Uceda](https://github.com/AlfonsoUceda) for the contribution.
+
 ## [0.9.4] - 30-09-20
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -306,3 +306,4 @@ lists is expected to follow the [code of conduct](https://github.com/toptal/data
 - [Evgeniy Demin](https://github.com/djezzzl) (author)
 - [Filipp Pirozhkov](https://github.com/pirj)
 - [Maxim Krizhanovski](https://github.com/Darhazer)
+- [Alfonso Uceda](https://github.com/AlfonsoUceda)

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -1,1 +1,0 @@
-gem 'activerecord', '>= 6.0'

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -1,0 +1,1 @@
+gem 'activerecord', '>= 6.1'

--- a/lib/database_validations/lib/adapters.rb
+++ b/lib/database_validations/lib/adapters.rb
@@ -8,7 +8,13 @@ module DatabaseValidations
     module_function
 
     def factory(model)
-      case (database = model.connection_config[:adapter].downcase.to_sym)
+      database = if ActiveRecord.version < Gem::Version.new('6.1.0')
+                   model.connection_config[:adapter].downcase.to_sym
+                 else
+                   model.connection_db_config.adapter.downcase.to_sym
+                 end
+
+      case database
       when SqliteAdapter::ADAPTER then SqliteAdapter
       when PostgresqlAdapter::ADAPTER then PostgresqlAdapter
       when MysqlAdapter::ADAPTER then MysqlAdapter

--- a/spec/validations/validates_db_uniqueness_of_spec.rb
+++ b/spec/validations/validates_db_uniqueness_of_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe '.validates_db_uniqueness_of' do
           expect(new.errors.messages).to be_present
           RAILS_5 && (expect(new.errors.details).to be_present)
 
-          expect(old.errors.messages).to include(new.errors.messages)
-          RAILS_5 && (expect(old.errors.details).to include(new.errors.details))
+          expect(old.errors.messages.to_h).to include(new.errors.messages.to_h)
+          RAILS_5 && (expect(old.errors.details.to_h).to include(new.errors.details.to_h))
         end
 
         context 'when wrapped by transaction' do
@@ -92,8 +92,8 @@ RSpec.describe '.validates_db_uniqueness_of' do
             expect(new.errors.messages).to be_present
             RAILS_5 && (expect(new.errors.details).to be_present)
 
-            expect(old.errors.messages).to include(new.errors.messages)
-            RAILS_5 && (expect(old.errors.details).to include(new.errors.details))
+            expect(old.errors.messages.to_h).to include(new.errors.messages.to_h)
+            RAILS_5 && (expect(old.errors.details.to_h).to include(new.errors.details.to_h))
           end
         end
       end


### PR DESCRIPTION
`ActiveRecord::Base.connection_config` is deprecated in rails 6.1 in favour of `ActiveRecord::Base.connection_db_config` and it will be removed in rails 6.2