### PR TITLE
Spread keyword arguments for ruby 3

### DIFF
--- a/lib/database_validations/lib/validators/db_uniqueness_validator.rb
+++ b/lib/database_validations/lib/validators/db_uniqueness_validator.rb
@@ -41,7 +41,7 @@ module DatabaseValidations
       error_options = options.except(:case_sensitive, :scope, :conditions)
       error_options[:value] = instance.public_send(attribute)
 
-      instance.errors.add(attribute, :taken, error_options)
+      instance.errors.add(attribute, :taken, **error_options)
     end
 
     private


### PR DESCRIPTION
It looks like Ruby 3 changes some things around now keyword arguments is handled causing you to get and `ArgumentError wrong number of arguments (given 3, expected 1..2)` with three arguments. You can see some more discussion about it on [this rails issue](https://github.com/rails/rails/issues/41270)

I tested this change on a few different versions of Ruby and all seemed fine. I was going to add another CI configuration for Ruby 3, but the [`railsmaster`](https://github.com/toptal/database_validations/blob/master/.circleci/config.yml#L111) configuration _should_ catch it it but isn't included in the main workflow, so wasn't sure if that was something you wanted.

Let me know and I can add another CI for rails6.1/ruby3 in this or another PR.

Thanks!