### PR TITLE
Version 2.1.1 is released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased - xxxx-xx-xx
 
+## [2.1.1] - 2026-03-31
+- `lint_roller` is removed as dependency. It is not needed
+
 ## [2.1.0] - 2026-03-31
 - Add RuboCop plugin system via LintRoller for RuboCop >= 1.72
 

--- a/database_validations.gemspec
+++ b/database_validations.gemspec
@@ -24,7 +24,6 @@ and ActiveRecord validations with better performance and consistency."
   spec.metadata['default_lint_roller_plugin'] = 'RuboCop::DatabaseValidations::Plugin'
 
   spec.add_dependency 'activerecord', '>= 7.2.0'
-  spec.add_dependency 'lint_roller'
 
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'bundler'

--- a/lib/database_validations/version.rb
+++ b/lib/database_validations/version.rb
@@ -1,3 +1,3 @@
 module DatabaseValidations
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end


### PR DESCRIPTION
lint_roller dependency is not needed.